### PR TITLE
added shim for AWS SSO. 

### DIFF
--- a/stx/aws.go
+++ b/stx/aws.go
@@ -16,6 +16,10 @@ import (
 
 // EnsureVaultSession is used to prompt for MFA if aws-vault session has expired
 func EnsureVaultSession(config *Config) {
+	if config.Auth.AWS_SSO {
+		return
+	}
+
 	au := aurora.NewAurora(true)
 	_, existingVault := os.LookupEnv("AWS_VAULT")
 	if existingVault {

--- a/stx/config.go
+++ b/stx/config.go
@@ -22,6 +22,7 @@ type Flags struct {
 
 const configCue = `package stx
 Auth: {
+	AWS_SSO: bool | *false
 	AwsVault: SourceProfile: string | *""
 	Ykman: Profile: string | *""
 }
@@ -43,6 +44,7 @@ type Config struct {
 	OsSeparator string
 	PackageName string
 	Auth        struct {
+		AWS_SSO  bool
 		AwsVault struct {
 			SourceProfile string
 		}


### PR DESCRIPTION
This still assumes the use of aws-vault. 

~/.aws/config must include SSO parameters.